### PR TITLE
Adding rack-cors gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'activeadmin', git: 'https://github.com/activeadmin/activeadmin'
 gem 'sidekiq', '~> 4.2.9'
 gem 'sinatra', github: 'sinatra/sinatra'
 gem 'sidekiq-cron', '~> 0.4.5'
+gem 'rack-cors', '~> 0.4.1'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,13 @@ module Librarium
     # -- all .rb files in that directory are automatically loaded.
     config.autoload_paths += %W(#{config.root}/app/queries)
     config.active_job.queue_adapter = :sidekiq
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '*', :headers => :any, 
+                      :methods => [:get, :put, :post, :options]
+      end
+    end
   end
 end


### PR DESCRIPTION
# Summary

* Add and configure rack-cors gem to overcome cors issues when posting from the Librarium AngularJS app to the Librarium Rails API via restangular.

# Trello Card

I came across this issue while working in an AngularJS project Trello Card:

https://trello.com/c/WzSOVkiW/2-crear-registro-de-usuarios